### PR TITLE
Support nil request in bridge.MessageSend

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -28,8 +28,12 @@ func MessageClose(c MessageChannel) bool {
 
 // MessageSend sends a request through a MessageChannel
 func MessageSend(c MessageChannel, request []byte) bool {
-	buffer := (*C.uchar)(unsafe.Pointer(&request[0]))
-	status := C.Message_Send(c, buffer, (C.size_t)(C.int(len(request))))
+	n := len(request)
+	var buffer *C.uchar
+	if n > 0 {
+		buffer = (*C.uchar)(unsafe.Pointer(&request[0]))
+	}
+	status := C.Message_Send(c, buffer, C.size_t(n))
 	return status != 0
 }
 


### PR DESCRIPTION
Avoids panic if request is nil or 0 length.

This enables support for incoming RPCs, where MessageSend(c, nil) makes
the vmx aware we are available to receive a request.