### PR TITLE
Reply to vmx with error status

### DIFF
--- a/bdoor/bdoor.go
+++ b/bdoor/bdoor.go
@@ -82,7 +82,6 @@ func (p *BackdoorProto) InOut() *BackdoorProto {
 }
 
 func (p *BackdoorProto) HighBandwidthOut() *BackdoorProto {
-
 	p.DX.Low.Low = BackdoorHighBWPort
 	p.AX.SetQuad(BackdoorMagic)
 
@@ -109,7 +108,6 @@ func (p *BackdoorProto) HighBandwidthOut() *BackdoorProto {
 }
 
 func (p *BackdoorProto) HighBandwidthIn() *BackdoorProto {
-
 	p.DX.Low.Low = BackdoorHighBWPort
 	p.AX.SetQuad(BackdoorMagic)
 

--- a/message/message.go
+++ b/message/message.go
@@ -32,6 +32,7 @@ const (
 	MessageTypeReceiveStatus
 	MessageTypeClose
 
+	MessageStatusFail      = uint16(0x0000)
 	MessageStatusSuccess   = uint16(0x0001)
 	MessageSatusDoReceive  = uint16(0x0002)
 	MessageSatusCheckPoint = uint16(0x0010)
@@ -128,6 +129,11 @@ retry:
 		return ErrRpciSend
 	}
 
+	// size of buf 0 is fine, just return
+	if len(buf) == 0 {
+		return nil
+	}
+
 	if !c.forceLowBW && (out.CX.Low.High&MessageSatusHighBW) == MessageSatusHighBW {
 		hbbp := &bdoor.BackdoorProto{}
 
@@ -212,85 +218,118 @@ retry:
 	}
 
 	size := out.BX.Quad()
+
 	var buf []byte
 
-	if !c.forceLowBW && (out.CX.Low.High&MessageSatusHighBW) == MessageSatusHighBW {
-		buf = make([]byte, size)
+	if size != 0 {
+		if !c.forceLowBW && (out.CX.Low.High&MessageSatusHighBW) == MessageSatusHighBW {
+			buf = make([]byte, size)
 
-		hbbp := &bdoor.BackdoorProto{}
+			hbbp := &bdoor.BackdoorProto{}
 
-		hbbp.BX.Low.Low = bdoor.CommandHighBWMessage
-		hbbp.BX.Low.High = MessageStatusSuccess
-		hbbp.DX.Low.High = c.id
-		hbbp.SI.Low.SetWord(c.cookie.High.Word())
-		hbbp.BP.Low.SetWord(c.cookie.Low.Word())
-		hbbp.CX.Low.SetWord(uint32(len(buf)))
-		hbbp.DI.SetQuad(uint64(uintptr(unsafe.Pointer(&buf[0]))))
+			hbbp.BX.Low.Low = bdoor.CommandHighBWMessage
+			hbbp.BX.Low.High = MessageStatusSuccess
+			hbbp.DX.Low.High = c.id
+			hbbp.SI.Low.SetWord(c.cookie.High.Word())
+			hbbp.BP.Low.SetWord(c.cookie.Low.Word())
+			hbbp.CX.Low.SetWord(uint32(len(buf)))
+			hbbp.DI.SetQuad(uint64(uintptr(unsafe.Pointer(&buf[0]))))
 
-		out := hbbp.HighBandwidthIn()
-		if (out.BX.Low.High & MessageStatusSuccess) == 0 {
-			Errorf("Message: Unable to send a message over the communication channel %d", c.id)
-			return nil, ErrRpciReceive
-		}
-	} else {
-		b := bytes.NewBuffer(make([]byte, 0, size))
-
-		for {
-			if size == 0 {
-				break
+			out := hbbp.HighBandwidthIn()
+			if (out.BX.Low.High & MessageStatusSuccess) == 0 {
+				Errorf("Message: Unable to send a message over the communication channel %d", c.id)
+				c.reply(MessageTypeReceivePayload, MessageStatusFail)
+				return nil, ErrRpciReceive
 			}
+		} else {
+			b := bytes.NewBuffer(make([]byte, 0, size))
 
-			bp.CX.Low.High = MessageTypeReceivePayload
-			bp.BX.Low.Low = MessageStatusSuccess
-
-			out = bp.InOut()
-			if (out.CX.Low.High & MessageStatusSuccess) == 0 {
-				if (out.CX.Low.High & MessageSatusCheckPoint) != 0 {
-					Debugf("A checkpoint occurred. Retrying the operation")
-					goto retry
+			for {
+				if size == 0 {
+					break
 				}
 
-				Errorf("Message: Unable to receive a message over the communication channel %d", c.id)
-				return nil, ErrRpciReceive
-			}
+				bp.CX.Low.High = MessageTypeReceivePayload
+				bp.BX.Low.Low = MessageStatusSuccess
 
-			if out.DX.Low.High != MessageTypeSendPayload {
-				Errorf("Message: Protocol error. Expected a MESSAGE_TYPE_SENDPAYLOAD from vmware")
-				return nil, ErrRpciReceive
-			}
+				out = bp.InOut()
+				if (out.CX.Low.High & MessageStatusSuccess) == 0 {
+					if (out.CX.Low.High & MessageSatusCheckPoint) != 0 {
+						Debugf("A checkpoint occurred. Retrying the operation")
+						goto retry
+					}
 
-			Debugf("Received %#v", out.BX.Low.Word())
+					Errorf("Message: Unable to receive a message over the communication channel %d", c.id)
+					c.reply(MessageTypeReceivePayload, MessageStatusFail)
+					return nil, ErrRpciReceive
+				}
 
-			switch size {
-			case 1:
-				err = binary.Write(b, binary.LittleEndian, uint8(out.BX.Low.Low))
-				size = size - 1
+				if out.DX.Low.High != MessageTypeSendPayload {
+					Errorf("Message: Protocol error. Expected a MESSAGE_TYPE_SENDPAYLOAD from vmware")
+					c.reply(MessageTypeReceivePayload, MessageStatusFail)
+					return nil, ErrRpciReceive
+				}
 
-			case 2:
-				err = binary.Write(b, binary.LittleEndian, uint16(out.BX.Low.Low))
-				size = size - 2
+				Debugf("Received %#v", out.BX.Low.Word())
 
-			case 3:
-				err = binary.Write(b, binary.LittleEndian, uint16(out.BX.Low.Low))
+				switch size {
+				case 1:
+					err = binary.Write(b, binary.LittleEndian, uint8(out.BX.Low.Low))
+					size = size - 1
+
+				case 2:
+					err = binary.Write(b, binary.LittleEndian, uint16(out.BX.Low.Low))
+					size = size - 2
+
+				case 3:
+					err = binary.Write(b, binary.LittleEndian, uint16(out.BX.Low.Low))
+					if err != nil {
+						c.reply(MessageTypeReceivePayload, MessageStatusFail)
+						return nil, ErrRpciReceive
+					}
+					err = binary.Write(b, binary.LittleEndian, uint8(out.BX.Low.High))
+					size = size - 3
+
+				default:
+					err = binary.Write(b, binary.LittleEndian, out.BX.Low.Word())
+					size = size - 4
+				}
+
 				if err != nil {
-					return nil, err
+					Errorf(err.Error())
+					c.reply(MessageTypeReceivePayload, MessageStatusFail)
+					return nil, ErrRpciReceive
 				}
-				err = binary.Write(b, binary.LittleEndian, uint8(out.BX.Low.High))
-				size = size - 3
-
-			default:
-				err = binary.Write(b, binary.LittleEndian, out.BX.Low.Word())
-				size = size - 4
 			}
 
-			if err != nil {
-				Errorf(err.Error())
-				return nil, ErrRpciReceive
-			}
+			buf = b.Bytes()
 		}
-
-		buf = b.Bytes()
 	}
 
+	c.reply(MessageTypeReceiveStatus, MessageStatusSuccess)
+
 	return buf, nil
+}
+
+func (c *Channel) reply(messageType, status uint16) {
+	bp := &bdoor.BackdoorProto{}
+
+	bp.BX.Low.Low = status
+	bp.CX.Low.High = messageType
+	bp.CX.Low.Low = bdoor.CommandMessage
+	bp.DX.Low.High = c.id
+	bp.SI.Low.SetWord(c.cookie.High.Word())
+	bp.DI.Low.SetWord(c.cookie.Low.Word())
+
+	out := bp.InOut()
+
+	/* OUT: Status */
+	if (out.CX.Low.High & MessageStatusSuccess) == 0 {
+		Errorf("type = 0x%x status = 0x%x", messageType, status)
+		if status == MessageStatusSuccess {
+			Errorf("reply Message: Unable to send a message over the communication channel %d", c.id)
+		} else {
+			Errorf("reply Message: Unable to signal an error of reception over the communication channel %d", c.id)
+		}
+	}
 }

--- a/message/message.go
+++ b/message/message.go
@@ -24,19 +24,19 @@ import (
 )
 
 const (
-	MessageTypeOpen = iota
-	MessageTypeSendSize
-	MessageTypeSendPayload
-	MessageTypeReceiveSize
-	MessageTypeReceivePayload
-	MessageTypeReceiveStatus
-	MessageTypeClose
+	messageTypeOpen = iota
+	messageTypeSendSize
+	messageTypeSendPayload
+	messageTypeReceiveSize
+	messageTypeReceivePayload
+	messageTypeReceiveStatus
+	messageTypeClose
 
-	MessageStatusFail      = uint16(0x0000)
-	MessageStatusSuccess   = uint16(0x0001)
-	MessageSatusDoReceive  = uint16(0x0002)
-	MessageSatusCheckPoint = uint16(0x0010)
-	MessageSatusHighBW     = uint16(0x0080)
+	messageStatusFail       = uint16(0x0000)
+	messageStatusSuccess    = uint16(0x0001)
+	messageStatusDoRecieve  = uint16(0x0002)
+	messageStatusCheckPoint = uint16(0x0010)
+	messageStatusHighBW     = uint16(0x0080)
 )
 
 var (
@@ -67,11 +67,11 @@ retry:
 	bp := &bdoor.BackdoorProto{}
 
 	bp.BX.Low.SetWord(proto | flags)
-	bp.CX.Low.High = MessageTypeOpen
+	bp.CX.Low.High = messageTypeOpen
 	bp.CX.Low.Low = bdoor.CommandMessage
 
 	out := bp.InOut()
-	if (out.CX.Low.High & MessageStatusSuccess) == 0 {
+	if (out.CX.Low.High & messageStatusSuccess) == 0 {
 		if flags != 0 {
 			flags = 0
 			goto retry
@@ -93,7 +93,7 @@ retry:
 func (c *Channel) Close() error {
 	bp := &bdoor.BackdoorProto{}
 
-	bp.CX.Low.High = MessageTypeClose
+	bp.CX.Low.High = messageTypeClose
 	bp.CX.Low.Low = bdoor.CommandMessage
 
 	bp.DX.Low.High = c.id
@@ -101,7 +101,7 @@ func (c *Channel) Close() error {
 	bp.DI.Low.SetWord(c.cookie.Low.Word())
 
 	out := bp.InOut()
-	if (out.CX.Low.High & MessageStatusSuccess) == 0 {
+	if (out.CX.Low.High & messageStatusSuccess) == 0 {
 		Errorf("Message: Unable to close communication channel %d", c.id)
 		return ErrChannelClose
 	}
@@ -113,7 +113,7 @@ func (c *Channel) Close() error {
 func (c *Channel) Send(buf []byte) error {
 retry:
 	bp := &bdoor.BackdoorProto{}
-	bp.CX.Low.High = MessageTypeSendSize
+	bp.CX.Low.High = messageTypeSendSize
 	bp.CX.Low.Low = bdoor.CommandMessage
 
 	bp.DX.Low.High = c.id
@@ -124,7 +124,7 @@ retry:
 
 	// send the size
 	out := bp.InOut()
-	if (out.CX.Low.High & MessageStatusSuccess) == 0 {
+	if (out.CX.Low.High & messageStatusSuccess) == 0 {
 		Errorf("Message: Unable to send a message over the communication channel %d", c.id)
 		return ErrRpciSend
 	}
@@ -134,11 +134,11 @@ retry:
 		return nil
 	}
 
-	if !c.forceLowBW && (out.CX.Low.High&MessageSatusHighBW) == MessageSatusHighBW {
+	if !c.forceLowBW && (out.CX.Low.High&messageStatusHighBW) == messageStatusHighBW {
 		hbbp := &bdoor.BackdoorProto{}
 
 		hbbp.BX.Low.Low = bdoor.CommandHighBWMessage
-		hbbp.BX.Low.High = MessageStatusSuccess
+		hbbp.BX.Low.High = messageStatusSuccess
 		hbbp.DX.Low.High = c.id
 		hbbp.BP.Low.SetWord(c.cookie.High.Word())
 		hbbp.DI.Low.SetWord(c.cookie.Low.Word())
@@ -146,8 +146,8 @@ retry:
 		hbbp.SI.SetQuad(uint64(uintptr(unsafe.Pointer(&buf[0]))))
 
 		out := hbbp.HighBandwidthOut()
-		if (out.BX.Low.High & MessageStatusSuccess) == 0 {
-			if (out.BX.Low.High & MessageSatusCheckPoint) != 0 {
+		if (out.BX.Low.High & messageStatusSuccess) == 0 {
+			if (out.BX.Low.High & messageStatusCheckPoint) != 0 {
 				Debugf("A checkpoint occurred. Retrying the operation")
 				goto retry
 			}
@@ -156,7 +156,7 @@ retry:
 			return ErrRpciSend
 		}
 	} else {
-		bp.CX.Low.High = MessageTypeSendPayload
+		bp.CX.Low.High = messageTypeSendPayload
 
 		bbuf := bytes.NewBuffer(buf)
 		for {
@@ -179,7 +179,7 @@ retry:
 			}
 
 			out = bp.InOut()
-			if (out.CX.Low.High & MessageStatusSuccess) == 0 {
+			if (out.CX.Low.High & messageStatusSuccess) == 0 {
 				Errorf("Message: Unable to send a message over the communication channel %d", c.id)
 				return ErrRpciSend
 			}
@@ -193,7 +193,7 @@ func (c *Channel) Receive() ([]byte, error) {
 retry:
 	var err error
 	bp := &bdoor.BackdoorProto{}
-	bp.CX.Low.High = MessageTypeReceiveSize
+	bp.CX.Low.High = messageTypeReceiveSize
 	bp.CX.Low.Low = bdoor.CommandMessage
 
 	bp.DX.Low.High = c.id
@@ -201,18 +201,18 @@ retry:
 	bp.DI.Low.SetWord(c.cookie.Low.Word())
 
 	out := bp.InOut()
-	if (out.CX.Low.High & MessageStatusSuccess) == 0 {
+	if (out.CX.Low.High & messageStatusSuccess) == 0 {
 		Errorf("Message: Unable to poll for messages over the communication channel %d", c.id)
 		return nil, ErrRpciReceive
 	}
 
-	if (out.CX.Low.High & MessageSatusDoReceive) == 0 {
+	if (out.CX.Low.High & messageStatusDoRecieve) == 0 {
 		Debugf("No message to retrieve")
 		return nil, nil
 	}
 
 	// Receive the size.
-	if out.DX.Low.High != MessageTypeSendSize {
+	if out.DX.Low.High != messageTypeSendSize {
 		Errorf("Message: Protocol error. Expected a MESSAGE_TYPE_SENDSIZE request from vmware")
 		return nil, ErrRpciReceive
 	}
@@ -222,13 +222,13 @@ retry:
 	var buf []byte
 
 	if size != 0 {
-		if !c.forceLowBW && (out.CX.Low.High&MessageSatusHighBW) == MessageSatusHighBW {
+		if !c.forceLowBW && (out.CX.Low.High&messageStatusHighBW == messageStatusHighBW) {
 			buf = make([]byte, size)
 
 			hbbp := &bdoor.BackdoorProto{}
 
 			hbbp.BX.Low.Low = bdoor.CommandHighBWMessage
-			hbbp.BX.Low.High = MessageStatusSuccess
+			hbbp.BX.Low.High = messageStatusSuccess
 			hbbp.DX.Low.High = c.id
 			hbbp.SI.Low.SetWord(c.cookie.High.Word())
 			hbbp.BP.Low.SetWord(c.cookie.Low.Word())
@@ -236,9 +236,9 @@ retry:
 			hbbp.DI.SetQuad(uint64(uintptr(unsafe.Pointer(&buf[0]))))
 
 			out := hbbp.HighBandwidthIn()
-			if (out.BX.Low.High & MessageStatusSuccess) == 0 {
+			if (out.BX.Low.High & messageStatusSuccess) == 0 {
 				Errorf("Message: Unable to send a message over the communication channel %d", c.id)
-				c.reply(MessageTypeReceivePayload, MessageStatusFail)
+				c.reply(messageTypeReceivePayload, messageStatusFail)
 				return nil, ErrRpciReceive
 			}
 		} else {
@@ -249,24 +249,24 @@ retry:
 					break
 				}
 
-				bp.CX.Low.High = MessageTypeReceivePayload
-				bp.BX.Low.Low = MessageStatusSuccess
+				bp.CX.Low.High = messageTypeReceivePayload
+				bp.BX.Low.Low = messageStatusSuccess
 
 				out = bp.InOut()
-				if (out.CX.Low.High & MessageStatusSuccess) == 0 {
-					if (out.CX.Low.High & MessageSatusCheckPoint) != 0 {
+				if (out.CX.Low.High & messageStatusSuccess) == 0 {
+					if (out.CX.Low.High & messageStatusCheckPoint) != 0 {
 						Debugf("A checkpoint occurred. Retrying the operation")
 						goto retry
 					}
 
 					Errorf("Message: Unable to receive a message over the communication channel %d", c.id)
-					c.reply(MessageTypeReceivePayload, MessageStatusFail)
+					c.reply(messageTypeReceivePayload, messageStatusFail)
 					return nil, ErrRpciReceive
 				}
 
-				if out.DX.Low.High != MessageTypeSendPayload {
+				if out.DX.Low.High != messageTypeSendPayload {
 					Errorf("Message: Protocol error. Expected a MESSAGE_TYPE_SENDPAYLOAD from vmware")
-					c.reply(MessageTypeReceivePayload, MessageStatusFail)
+					c.reply(messageTypeReceivePayload, messageStatusFail)
 					return nil, ErrRpciReceive
 				}
 
@@ -284,7 +284,7 @@ retry:
 				case 3:
 					err = binary.Write(b, binary.LittleEndian, uint16(out.BX.Low.Low))
 					if err != nil {
-						c.reply(MessageTypeReceivePayload, MessageStatusFail)
+						c.reply(messageTypeReceivePayload, messageStatusFail)
 						return nil, ErrRpciReceive
 					}
 					err = binary.Write(b, binary.LittleEndian, uint8(out.BX.Low.High))
@@ -297,7 +297,7 @@ retry:
 
 				if err != nil {
 					Errorf(err.Error())
-					c.reply(MessageTypeReceivePayload, MessageStatusFail)
+					c.reply(messageTypeReceivePayload, messageStatusFail)
 					return nil, ErrRpciReceive
 				}
 			}
@@ -306,15 +306,15 @@ retry:
 		}
 	}
 
-	c.reply(MessageTypeReceiveStatus, MessageStatusSuccess)
+	c.reply(messageTypeReceiveStatus, messageStatusSuccess)
 
 	return buf, nil
 }
 
-func (c *Channel) reply(messageType, status uint16) {
+func (c *Channel) reply(messageType, messageStatus uint16) {
 	bp := &bdoor.BackdoorProto{}
 
-	bp.BX.Low.Low = status
+	bp.BX.Low.Low = messageStatus
 	bp.CX.Low.High = messageType
 	bp.CX.Low.Low = bdoor.CommandMessage
 	bp.DX.Low.High = c.id
@@ -324,9 +324,8 @@ func (c *Channel) reply(messageType, status uint16) {
 	out := bp.InOut()
 
 	/* OUT: Status */
-	if (out.CX.Low.High & MessageStatusSuccess) == 0 {
-		Errorf("type = 0x%x status = 0x%x", messageType, status)
-		if status == MessageStatusSuccess {
+	if (out.CX.Low.High & messageStatusSuccess) == 0 {
+		if messageStatus == messageStatusSuccess {
 			Errorf("reply Message: Unable to send a message over the communication channel %d", c.id)
 		} else {
 			Errorf("reply Message: Unable to signal an error of reception over the communication channel %d", c.id)

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 const rpciProtocolNum uint32 = 0x49435052
+const tcloProtocol uint32 = 0x4f4c4354
 
 func TestOpenClose(t *testing.T) {
 	l := DefaultLogger.(*logger)
@@ -78,6 +79,44 @@ func TestOpenClose(t *testing.T) {
 	}
 
 	if !util.AssertNoError(t, ch.Close()) {
+		return
+	}
+}
+
+// Test we can reply to the rpcin
+func TestReset(t *testing.T) {
+	l := DefaultLogger.(*logger)
+	l.DebugLevel = true
+
+	if !vmcheck.IsVirtualWorld() {
+		t.Skip("Not in a virtual world")
+		return
+	}
+
+	ch, err := NewChannel(tcloProtocol)
+	if !util.AssertNotNil(t, ch) || !util.AssertNoError(t, err) {
+		return
+	}
+	defer ch.Close()
+
+	var buf []byte
+
+	for {
+		_ = ch.Send(buf)
+		request, _ := ch.Receive()
+
+		if len(request) == 0 {
+			continue
+		}
+
+		if string(request) == "reset" {
+			break
+		}
+	}
+
+	reply := "OK ATR toolbox"
+	err = ch.Send([]byte(reply))
+	if !util.AssertNoError(t, err) {
 		return
 	}
 }

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -15,6 +15,7 @@
 package message
 
 import (
+	"os"
 	"testing"
 
 	"github.com/vmware/vmw-guestinfo/util"
@@ -90,6 +91,11 @@ func TestReset(t *testing.T) {
 
 	if !vmcheck.IsVirtualWorld() {
 		t.Skip("Not in a virtual world")
+		return
+	}
+
+	if os.Getenv("TEST_TOOLBOX") == "" {
+		t.Skip("Skipping toolbox test")
 		return
 	}
 


### PR DESCRIPTION
We weren't signalling to the vmx that there was an error.  That was
breaking the protocol.  Also, zero sized buffers are treated as NOOPs to
the vmx and used as a heartbeat by tools.  This was causing a PANIC
because the buffer size wasn't being checked.