### PR TITLE
Export CpuIsVM

### DIFF
--- a/vmcheck/vmcheck_linux.go
+++ b/vmcheck/vmcheck_linux.go
@@ -28,7 +28,7 @@ func cpuid_low(arg1, arg2 uint32) (eax, ebx, ecx, edx uint32)
 // IsVirtualWorld returns true if running in a VM and the backdoor is available.
 func IsVirtualWorld() (bool, error) {
 	// Test the HV bit is set
-	if !CpuIsVM() {
+	if !IsVirtualCPU() {
 		return false, nil
 	}
 
@@ -56,14 +56,14 @@ func hypervisorPortCheck() (bool, error) {
 	return (0xffffffff != out.AX.Low.Word()) && (0 != out.AX.Low.Word()), nil
 }
 
-// CpuIsVM checks if the cpu is a virtual CPU running on ESX.  It checks for
+// IsVirtualCPU checks if the cpu is a virtual CPU running on ESX.  It checks for
 // the HV bit in the ECX register of the CPUID leaf 0x1.  Intel and AMD CPUs
 // reserve this bit to indicate if the CPU is running in a HV. See
 // https://en.wikipedia.org/wiki/CPUID#EAX.3D1:_Processor_Info_and_Feature_Bits
 // for details.  If this bit is set, the reserved cpuid levels are used to pass
 // information from the HV to the guest.  In ESX, this is the repeating string
 // "VMwareVMware".
-func CpuIsVM() bool {
+func IsVirtualCPU() bool {
 	HV := uint32(1 << 31)
 	_, _, c, _ := cpuid_low(0x1, 0)
 	if (c & HV) != HV {

--- a/vmcheck/vmcheck_linux.go
+++ b/vmcheck/vmcheck_linux.go
@@ -25,10 +25,10 @@ import (
 // Get the CPU ID low level leaf values.
 func cpuid_low(arg1, arg2 uint32) (eax, ebx, ecx, edx uint32)
 
-// IsVirtualWorld returns true if running in a VM.
+// IsVirtualWorld returns true if running in a VM and the backdoor is available.
 func IsVirtualWorld() (bool, error) {
 	// Test the HV bit is set
-	if !cpuIsVM() {
+	if !CpuIsVM() {
 		return false, nil
 	}
 
@@ -56,13 +56,14 @@ func hypervisorPortCheck() (bool, error) {
 	return (0xffffffff != out.AX.Low.Word()) && (0 != out.AX.Low.Word()), nil
 }
 
-// cpuIsVM checks for the HV bit in the ECX register of the CPUID leaf 0x1.
-// Intel and AMD CPUs reserve this bit to indicate if the CPU is running
-// in a HV. See https://en.wikipedia.org/wiki/CPUID#EAX.3D1:_Processor_Info_and_Feature_Bits
+// CpuIsVM checks if the cpu is a virtual CPU running on ESX.  It checks for
+// the HV bit in the ECX register of the CPUID leaf 0x1.  Intel and AMD CPUs
+// reserve this bit to indicate if the CPU is running in a HV. See
+// https://en.wikipedia.org/wiki/CPUID#EAX.3D1:_Processor_Info_and_Feature_Bits
 // for details.  If this bit is set, the reserved cpuid levels are used to pass
 // information from the HV to the guest.  In ESX, this is the repeating string
-// VMwareVMware.
-func cpuIsVM() bool {
+// "VMwareVMware".
+func CpuIsVM() bool {
 	HV := uint32(1 << 31)
 	_, _, c, _ := cpuid_low(0x1, 0)
 	if (c & HV) != HV {

--- a/vmcheck/vmcheck_test.go
+++ b/vmcheck/vmcheck_test.go
@@ -27,7 +27,7 @@ func TestIsVirtualWorld(t *testing.T) {
 	}
 
 	t.Log("Backdoor available: ", isBackdoor)
-	t.Log("CPU HV: ", CpuIsVM())
+	t.Log("CPU HV: ", IsVirtualCPU())
 
 	isVM, err := IsVirtualWorld()
 	if !util.AssertNoError(t, err) {

--- a/vmcheck/vmcheck_test.go
+++ b/vmcheck/vmcheck_test.go
@@ -27,7 +27,7 @@ func TestIsVirtualWorld(t *testing.T) {
 	}
 
 	t.Log("Backdoor available: ", isVm)
-	t.Log("CPU HV: ", cpuIsVM())
+	t.Log("CPU HV: ", CpuIsVM())
 
 	isVM, err := IsVirtualWorld()
 	if !util.AssertNoError(t, err) {

--- a/vmcheck/vmcheck_test.go
+++ b/vmcheck/vmcheck_test.go
@@ -21,12 +21,12 @@ import (
 )
 
 func TestIsVirtualWorld(t *testing.T) {
-	isVm, err := hypervisorPortCheck()
+	isBackdoor, err := hypervisorPortCheck()
 	if !util.AssertNoError(t, err) {
 		return
 	}
 
-	t.Log("Backdoor available: ", isVm)
+	t.Log("Backdoor available: ", isBackdoor)
 	t.Log("CPU HV: ", CpuIsVM())
 
 	isVM, err := IsVirtualWorld()


### PR DESCRIPTION
The IsVirtualWorld() check requires UID 0 and often all we want to know
is if we're in a VM.