### PR TITLE
move test helpers to internal package

### DIFF
--- a/bdoor/bdoor_386_test.go
+++ b/bdoor/bdoor_386_test.go
@@ -17,7 +17,7 @@ package bdoor
 import (
 	"testing"
 
-	"github.com/vmware/vmw-guestinfo/util"
+	"github.com/vmware/vmw-guestinfo/internal"
 )
 
 func TestBdoorArgAlignment(t *testing.T) {
@@ -31,13 +31,11 @@ func TestBdoorArgAlignment(t *testing.T) {
 
 	oa, ob, oc, od, osi, odi, obp := bdoor_inout_test(a, b, c, d, si, di, bp)
 
-	if !util.AssertEqual(t, a, oa) ||
-		!util.AssertEqual(t, b, ob) ||
-		!util.AssertEqual(t, c, oc) ||
-		!util.AssertEqual(t, d, od) ||
-		!util.AssertEqual(t, si, osi) ||
-		!util.AssertEqual(t, di, odi) ||
-		!util.AssertEqual(t, bp, obp) {
-		return
-	}
+	internal.AssertEqual(t, a, oa)
+	internal.AssertEqual(t, b, ob)
+	internal.AssertEqual(t, c, oc)
+	internal.AssertEqual(t, d, od)
+	internal.AssertEqual(t, si, osi)
+	internal.AssertEqual(t, di, odi)
+	internal.AssertEqual(t, bp, obp)
 }

--- a/bdoor/bdoor_amd64_test.go
+++ b/bdoor/bdoor_amd64_test.go
@@ -17,7 +17,7 @@ package bdoor
 import (
 	"testing"
 
-	"github.com/vmware/vmw-guestinfo/util"
+	"github.com/vmware/vmw-guestinfo/internal"
 )
 
 func TestBdoorArgAlignment(t *testing.T) {
@@ -31,13 +31,11 @@ func TestBdoorArgAlignment(t *testing.T) {
 
 	oa, ob, oc, od, osi, odi, obp := bdoor_inout_test(a, b, c, d, si, di, bp)
 
-	if !util.AssertEqual(t, a, oa) ||
-		!util.AssertEqual(t, b, ob) ||
-		!util.AssertEqual(t, c, oc) ||
-		!util.AssertEqual(t, d, od) ||
-		!util.AssertEqual(t, si, osi) ||
-		!util.AssertEqual(t, di, odi) ||
-		!util.AssertEqual(t, bp, obp) {
-		return
-	}
+	internal.AssertEqual(t, a, oa)
+	internal.AssertEqual(t, b, ob)
+	internal.AssertEqual(t, c, oc)
+	internal.AssertEqual(t, d, od)
+	internal.AssertEqual(t, si, osi)
+	internal.AssertEqual(t, di, odi)
+	internal.AssertEqual(t, bp, obp)
 }

--- a/bdoor/word_386_test.go
+++ b/bdoor/word_386_test.go
@@ -17,7 +17,7 @@ package bdoor
 import (
 	"testing"
 
-	"github.com/vmware/vmw-guestinfo/util"
+	"github.com/vmware/vmw-guestinfo/internal"
 )
 
 func TestSetWord(t *testing.T) {
@@ -29,11 +29,8 @@ func TestSetWord(t *testing.T) {
 	out.Low = inLow
 	out.High = inHigh
 
-	if !util.AssertEqual(t, inLow, out.Low) || !util.AssertEqual(t, inHigh, out.High) {
-		return
-	}
+	internal.AssertEqual(t, inLow, out.Low)
+	internal.AssertEqual(t, inHigh, out.High)
 
-	if !util.AssertEqual(t, uint32(0xBBBBEEFF), out.Word()) {
-		return
-	}
+	internal.AssertEqual(t, uint32(0xBBBBEEFF), out.Word())
 }

--- a/bdoor/word_amd64_test.go
+++ b/bdoor/word_amd64_test.go
@@ -15,8 +15,8 @@
 package bdoor
 
 import (
+	"github.com/vmware/vmw-guestinfo/internal"
 	"testing"
-	"github.com/vmware/vmw-guestinfo/util"
 )
 
 func TestSetWord(t *testing.T) {
@@ -28,13 +28,10 @@ func TestSetWord(t *testing.T) {
 	out.Low = inLow
 	out.High = inHigh
 
-	if !util.AssertEqual(t, inLow, out.Low) || !util.AssertEqual(t, inHigh, out.High) {
-		return
-	}
+	internal.AssertEqual(t, inLow, out.Low)
+	internal.AssertEqual(t, inHigh, out.High)
 
-	if !util.AssertEqual(t, uint32(0xBBBBEEFF), out.Word()) {
-		return
-	}
+	internal.AssertEqual(t, uint32(0xBBBBEEFF), out.Word())
 }
 
 func TestQuadToHighLow(t *testing.T) {
@@ -42,17 +39,9 @@ func TestQuadToHighLow(t *testing.T) {
 
 	var u UInt64
 	u.SetQuad(in)
-	if !util.AssertEqual(t, uint32(in), u.Low.Word()) {
-		return
-	}
-
-	if !util.AssertEqual(t, uint32(in>>32), u.High.Word()) {
-		return
-	}
-
-	if !util.AssertEqual(t, in, u.Quad()) {
-		return
-	}
+	internal.AssertEqual(t, uint32(in), u.Low.Word())
+	internal.AssertEqual(t, uint32(in>>32), u.High.Word())
+	internal.AssertEqual(t, in, u.Quad())
 }
 
 func TestHighLowToQuad(t *testing.T) {
@@ -64,7 +53,5 @@ func TestHighLowToQuad(t *testing.T) {
 		Low:  UInt32{Low: inLow},
 	}
 
-	if !util.AssertEqual(t, (uint64(inHigh)<<48)+uint64(inLow), u.Quad()) {
-		return
-	}
+	internal.AssertEqual(t, (uint64(inHigh)<<48)+uint64(inLow), u.Quad())
 }

--- a/internal/util.go
+++ b/internal/util.go
@@ -12,47 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package internal
 
 import (
 	"reflect"
-	"runtime"
 	"testing"
 )
 
 // Test utilities.
 
-func AssertEqual(t *testing.T, a interface{}, b interface{}) bool {
+func AssertEqual(t *testing.T, a interface{}, b interface{}) {
+	t.Helper()
 	if !reflect.DeepEqual(a, b) {
-		Fail(t)
-		return false
+		t.FailNow()
 	}
-
-	return true
 }
 
-func AssertNoError(t *testing.T, err error) bool {
+func AssertNoError(t *testing.T, err error) {
+	t.Helper()
 	if err != nil {
-		t.Logf("error :%s", err.Error())
-		Fail(t)
-		return false
+		t.Fatal(err)
 	}
-
-	return true
 }
 
-func AssertNotNil(t *testing.T, a interface{}) bool {
+func AssertNotNil(t *testing.T, a interface{}) {
+	t.Helper()
 	val := reflect.ValueOf(a)
 	if val.IsNil() {
-		Fail(t)
-		return false
+		t.FailNow()
 	}
-
-	return true
-}
-
-func Fail(t *testing.T) {
-	_, file, line, _ := runtime.Caller(2)
-	t.Logf("FAIL on %s:%d", file, line)
-	t.Fail()
 }

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -18,7 +18,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/vmware/vmw-guestinfo/util"
+	"github.com/vmware/vmw-guestinfo/internal"
 	"github.com/vmware/vmw-guestinfo/vmcheck"
 )
 
@@ -36,53 +36,37 @@ func TestOpenClose(t *testing.T) {
 	}
 
 	ch, err := NewChannel(rpciProtocolNum)
-	if !util.AssertNotNil(t, ch) || !util.AssertNoError(t, err) {
-		return
-	}
+	internal.AssertNotNil(t, ch)
+	internal.AssertNoError(t, err)
 
 	// check low bandwidth
 	ch.forceLowBW = true
 	err = ch.Send([]byte("info-get guestinfo.doesnotexistdoesnotexit"))
-	if !util.AssertNoError(t, err) {
-		return
-	}
+	internal.AssertNoError(t, err)
 
 	b, err := ch.Receive()
-	if !util.AssertNoError(t, err) || !util.AssertNotNil(t, b) {
-		return
-	}
+	internal.AssertNoError(t, err)
+	internal.AssertNotNil(t, b)
 
-	if !util.AssertEqual(t, "0 No value found", string(b)) {
-		return
-	}
+	internal.AssertEqual(t, "0 No value found", string(b))
 
-	if !util.AssertNoError(t, ch.Close()) {
-		return
-	}
+	internal.AssertNoError(t, ch.Close())
 
 	// check high bandwidth
 	ch, err = NewChannel(rpciProtocolNum)
-	if !util.AssertNotNil(t, ch) || !util.AssertNoError(t, err) {
-		return
-	}
+	internal.AssertNotNil(t, ch)
+	internal.AssertNoError(t, err)
 
 	err = ch.Send([]byte("info-get guestinfo.doesnotexistdoesnotexit"))
-	if !util.AssertNoError(t, err) {
-		return
-	}
+	internal.AssertNoError(t, err)
 
 	b, err = ch.Receive()
-	if !util.AssertNoError(t, err) || !util.AssertNotNil(t, b) {
-		return
-	}
+	internal.AssertNoError(t, err)
+	internal.AssertNotNil(t, b)
 
-	if !util.AssertEqual(t, "0 No value found", string(b)) {
-		return
-	}
+	internal.AssertEqual(t, "0 No value found", string(b))
 
-	if !util.AssertNoError(t, ch.Close()) {
-		return
-	}
+	internal.AssertNoError(t, ch.Close())
 }
 
 // Test we can reply to the rpcin
@@ -102,10 +86,9 @@ func TestReset(t *testing.T) {
 	}
 
 	ch, err := NewChannel(tcloProtocol)
-	if !util.AssertNotNil(t, ch) || !util.AssertNoError(t, err) {
-		return
-	}
+	internal.AssertNotNil(t, ch)
 	defer ch.Close()
+	internal.AssertNoError(t, err)
 
 	var buf []byte
 
@@ -124,7 +107,5 @@ func TestReset(t *testing.T) {
 
 	reply := "OK ATR toolbox"
 	err = ch.Send([]byte(reply))
-	if !util.AssertNoError(t, err) {
-		return
-	}
+	internal.AssertNoError(t, err)
 }

--- a/vmcheck/vmcheck_test.go
+++ b/vmcheck/vmcheck_test.go
@@ -17,21 +17,17 @@ package vmcheck
 import (
 	"testing"
 
-	"github.com/vmware/vmw-guestinfo/util"
+	"github.com/vmware/vmw-guestinfo/internal"
 )
 
 func TestIsVirtualWorld(t *testing.T) {
 	isBackdoor, err := hypervisorPortCheck()
-	if !util.AssertNoError(t, err) {
-		return
-	}
+	internal.AssertNoError(t, err)
 
 	t.Log("Backdoor available: ", isBackdoor)
 	t.Log("CPU HV: ", IsVirtualCPU())
 
 	isVM, err := IsVirtualWorld()
-	if !util.AssertNoError(t, err) {
-		return
-	}
+	internal.AssertNoError(t, err)
 	t.Log("Running in a VM: ", isVM)
 }


### PR DESCRIPTION
Also leverage t.Helper() instead of bespoke implementation.
Finally remove the returned boolean: it was only used as a way to replicate the
FailNow() behavior.