### PR TITLE
improve vmcheck testing

### DIFF
--- a/vmcheck/vmcheck.go
+++ b/vmcheck/vmcheck.go
@@ -20,51 +20,49 @@ import (
 	"github.com/vmware/vmw-guestinfo/bdoor"
 )
 
+type platform struct {
+	cpuid       func(uint32, uint32) (uint32, uint32, uint32, uint32)
+	accessPorts func() error
+	knock       func() (bool, error)
+}
+
+var defaultPlatform = &platform{
+	cpuid:       cpuid_low,
+	accessPorts: openPortsAccess,
+	knock:       bdoorKnock,
+}
+
 // From https://github.com/intel-go/cpuid/blob/master/cpuidlow_amd64.s
 // Get the CPU ID low level leaf values.
 func cpuid_low(arg1, arg2 uint32) (eax, ebx, ecx, edx uint32)
 
-// IsVirtualWorld returns true if running in a VM and the backdoor is available.
-func IsVirtualWorld() (bool, error) {
-	// Test the HV bit is set
-	if !IsVirtualCPU() {
-		return false, nil
-	}
+func bdoorKnock() (bool, error) {
+	bp := &bdoor.BackdoorProto{}
 
-	// Test if backdoor port is available.
-	return hypervisorPortCheck()
-}
-
-// hypervisorPortCheck tests the availability of the HV port.
-func hypervisorPortCheck() (bool, error) {
-	// Privilege level 3 to access all ports above 0x3ff
-	if err := openPortsAccess(); err != nil {
-		return false, err
-	}
-
-	p := &bdoor.BackdoorProto{}
-
-	p.CX.AsUInt32().SetWord(bdoor.CommandGetVersion)
-	out := p.InOut()
+	bp.CX.AsUInt32().SetWord(bdoor.CommandGetVersion)
+	out := bp.InOut()
 	// if there is no device, we get back all 1s
 	return (0xffffffff != out.AX.AsUInt32().Word()) && (0 != out.AX.AsUInt32().Word()), nil
 }
 
-// IsVirtualCPU checks if the cpu is a virtual CPU running on ESX.  It checks for
-// the HV bit in the ECX register of the CPUID leaf 0x1.  Intel and AMD CPUs
-// reserve this bit to indicate if the CPU is running in a HV. See
-// https://en.wikipedia.org/wiki/CPUID#EAX.3D1:_Processor_Info_and_Feature_Bits
-// for details.  If this bit is set, the reserved cpuid levels are used to pass
-// information from the HV to the guest.  In ESX, this is the repeating string
-// "VMwareVMware".
-func IsVirtualCPU() bool {
+func (p *platform) isVirtualWorld() (bool, error) {
+	// Test the HV bit is set
+	if !p.isVirtualCPU() {
+		return false, nil
+	}
+
+	// Test if backdoor port is available.
+	return p.hypervisorPortCheck()
+}
+
+func (p *platform) isVirtualCPU() bool {
 	HV := uint32(1 << 31)
-	_, _, c, _ := cpuid_low(0x1, 0)
+	_, _, c, _ := p.cpuid(0x1, 0)
 	if (c & HV) != HV {
 		return false
 	}
 
-	_, b, c, d := cpuid_low(0x40000000, 0)
+	_, b, c, d := p.cpuid(0x40000000, 0)
 
 	buf := make([]byte, 12)
 	binary.LittleEndian.PutUint32(buf, b)
@@ -76,4 +74,30 @@ func IsVirtualCPU() bool {
 	}
 
 	return true
+}
+
+// hypervisorPortCheck tests the availability of the HV port.
+func (p *platform) hypervisorPortCheck() (bool, error) {
+	// Privilege level 3 to access all ports above 0x3ff
+	if err := p.accessPorts(); err != nil {
+		return false, err
+	}
+
+	return p.knock()
+}
+
+// IsVirtualCPU checks if the cpu is a virtual CPU running on ESX.  It checks for
+// the HV bit in the ECX register of the CPUID leaf 0x1.  Intel and AMD CPUs
+// reserve this bit to indicate if the CPU is running in a HV. See
+// https://en.wikipedia.org/wiki/CPUID#EAX.3D1:_Processor_Info_and_Feature_Bits
+// for details.  If this bit is set, the reserved cpuid levels are used to pass
+// information from the HV to the guest.  In ESX, this is the repeating string
+// "VMwareVMware".
+func IsVirtualCPU() bool {
+	return defaultPlatform.isVirtualCPU()
+}
+
+// IsVirtualWorld returns true if running in a VM and the backdoor is available.
+func IsVirtualWorld() (bool, error) {
+	return defaultPlatform.isVirtualWorld()
 }

--- a/vmcheck/vmcheck_test.go
+++ b/vmcheck/vmcheck_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestIsVirtualWorld(t *testing.T) {
-	isBackdoor, err := hypervisorPortCheck()
+	isBackdoor, err := defaultPlatform.hypervisorPortCheck()
 	internal.AssertNoError(t, err)
 
 	t.Log("Backdoor available: ", isBackdoor)

--- a/vmcheck/vmcheck_test.go
+++ b/vmcheck/vmcheck_test.go
@@ -15,19 +15,80 @@
 package vmcheck
 
 import (
+	"encoding/binary"
+	"fmt"
 	"testing"
-
-	"github.com/vmware/vmw-guestinfo/internal"
 )
 
-func TestIsVirtualWorld(t *testing.T) {
-	isBackdoor, err := defaultPlatform.hypervisorPortCheck()
-	internal.AssertNoError(t, err)
+var (
+	intelID = []byte("GenuineIntel")
+	vmwID   = []byte("VMwareVMware")
 
-	t.Log("Backdoor available: ", isBackdoor)
-	t.Log("CPU HV: ", IsVirtualCPU())
+	errPerm   = fmt.Errorf("operation not permitted")
+	errAccess = fmt.Errorf("access denied")
+)
 
-	isVM, err := IsVirtualWorld()
-	internal.AssertNoError(t, err)
-	t.Log("Running in a VM: ", isVM)
+func TestVirtualWorld(t *testing.T) {
+	leUint32 := binary.LittleEndian.Uint32
+	data := []struct {
+		scenario   string
+		hv         bool
+		id         []byte
+		portAccess error
+		bdoorKnock error
+		resp       bool
+	}{
+		{"vmware", true, vmwID, nil, nil, true},
+		{"vmware no backdoor", true, vmwID, errPerm, errAccess, false},
+		{"physical", false, intelID, errPerm, errAccess, false},
+	}
+
+	for _, tt := range data {
+		tt := tt
+		t.Run(tt.scenario, func(t *testing.T) {
+			p := platform{
+				accessPorts: func() error { return tt.portAccess },
+				cpuid: func(eax, _ uint32) (uint32, uint32, uint32, uint32) {
+					if eax == 0x1 {
+						if tt.hv {
+							return 0, 0, uint32(1 << 31), 0
+						}
+						return 0, 0, 0, 0
+					}
+					if eax == 0x40000000 {
+						return 0, leUint32(tt.id[:]), leUint32(tt.id[4:]), leUint32(tt.id[8:])
+					}
+					t.Fatal(fmt.Errorf("unexpected cpuid call"))
+					return 0, 0, 0, 0
+				},
+				knock: func() (bool, error) {
+					if tt.bdoorKnock == nil {
+						return true, nil
+					}
+					return false, tt.bdoorKnock
+				},
+			}
+			v, err := p.isVirtualWorld()
+			if tt.resp {
+				if !v || err != nil {
+					t.Fatal("expected to be virtual")
+				}
+				return
+			}
+
+			if v {
+				t.Fatal("wrongly detected as virtual")
+			}
+
+			if err != nil {
+				if tt.portAccess != nil && err == tt.portAccess {
+					return
+				}
+				if tt.bdoorKnock != nil && err == tt.bdoorKnock {
+					return
+				}
+				t.Fatal("unexpected error")
+			}
+		})
+	}
 }


### PR DESCRIPTION
vmcheck tests have been fundamentally broken since the beginning: by actually running asm code on the host, they couldn't possibly work in a portable way.

This change adds a small abstraction layer that enables simulating multiple situations.