### PR TITLE
vmcheck: allow ignoring iopl errors

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -38,7 +38,7 @@ func init() {
 
 func main() {
 
-	isVM, err := vmcheck.IsVirtualWorld()
+	isVM, err := vmcheck.IsVirtualWorld(true)
 	if err != nil {
 		log.Fatalf("Error: %s", err)
 	}

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -29,7 +29,7 @@ func TestOpenClose(t *testing.T) {
 	l := DefaultLogger.(*logger)
 	l.DebugLevel = true
 
-	isVm, err := vmcheck.IsVirtualWorld()
+	isVm, err := vmcheck.IsVirtualWorld(true)
 	if err != nil || !isVm {
 		t.Skip("Not in a virtual world")
 		return
@@ -74,7 +74,7 @@ func TestReset(t *testing.T) {
 	l := DefaultLogger.(*logger)
 	l.DebugLevel = true
 
-	isVm, err := vmcheck.IsVirtualWorld()
+	isVm, err := vmcheck.IsVirtualWorld(true)
 	if err != nil || !isVm {
 		t.Skip("Not in a virtual world")
 		return

--- a/vmcheck/vmcheck_test.go
+++ b/vmcheck/vmcheck_test.go
@@ -68,7 +68,7 @@ func TestVirtualWorld(t *testing.T) {
 					return false, tt.bdoorKnock
 				},
 			}
-			v, err := p.isVirtualWorld()
+			v, err := p.isVirtualWorld(false)
 			if tt.resp {
 				if !v || err != nil {
 					t.Fatal("expected to be virtual")


### PR DESCRIPTION
This introduces an additional flag for the VM-checking logic,
in order to allow consuming applications to keep going when changing
I/O access level is not alloewd (see `kernel_lockdown(7)` on Linux).
In most cases the library may work without higher I/O level,
and actual failures can be handled via normal error-handling on RPC
methods.

Ref: https://github.com/vmware/vmw-guestinfo/issues/20