### PR TITLE
mark assembly files as compatible with gc toolchain only

### DIFF
--- a/bdoor/bdoor_386.s
+++ b/bdoor/bdoor_386.s
@@ -1,3 +1,5 @@
+// +build gc
+
 #include "textflag.h"
 
 // Doc of the golang plan9 assembler

--- a/bdoor/bdoor_amd64.s
+++ b/bdoor/bdoor_amd64.s
@@ -1,3 +1,5 @@
+// +build gc
+
 #include "textflag.h"
 
 // Doc of the golang plan9 assembler

--- a/vmcheck/vmcheck_386.s
+++ b/vmcheck/vmcheck_386.s
@@ -1,3 +1,5 @@
+// +build gc
+
 #include "textflag.h"
 
 // From https://github.com/intel-go/cpuid/blob/master/cpuidlow_amd64.s

--- a/vmcheck/vmcheck_amd64.s
+++ b/vmcheck/vmcheck_amd64.s
@@ -1,3 +1,5 @@
+// +build gc
+
 #include "textflag.h"
 
 // From https://github.com/intel-go/cpuid/blob/master/cpuidlow_amd64.s


### PR DESCRIPTION
Issue #19 shows that building with llvmgo (or gccgo) currently fails with an unclear message.
This is because it tries to compile .s files that are using a gc-specific format.
A complete solution would introduce .s files that do compile with those alternate toolchains,
but at least we'll now have a clearer error (undefined reference to a bunch of functions)